### PR TITLE
Fixes #9 Test-ARMexistingResource takes whole RG into account. 

### DIFF
--- a/ARMHelper/ARMHelper.format.ps1xml
+++ b/ARMHelper/ARMHelper.format.ps1xml
@@ -51,6 +51,7 @@
                     <Width>50</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                    <Label>Current ResourcegroupName</Label>
                     </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>

--- a/ARMHelper/ARMHelper.psd1
+++ b/ARMHelper/ARMHelper.psd1
@@ -10,7 +10,7 @@
     RootModule        = 'ArmHelper.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.1.0'
+    ModuleVersion     = '0.1.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/ARMHelper/Public/Test-ARMexistingResource.ps1
+++ b/ARMHelper/Public/Test-ARMexistingResource.ps1
@@ -151,7 +151,7 @@ Function Test-ARMExistingResource {
         Write-Output ""
     }
     if ($DifferentResourcegroup.Count -ne 0) {
-        Write-Output "The following resources exists, but in a different ResourceGroup. This deployment might fail.`n"
+        Write-Output "A resource of the same type and same name exists in other resourcegroup(s). This deployment might fail.`n"
         # Write-Output "Resourcegroup for this deployment: $ResourceGroupName"
         $DifferentResourcegroup
         Write-Output ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2019-04-11
+
+### Fixed #9 Test-ARMExistingResource should output all resource group changes with complete switch
+
 ## [0.1.0] - 2019-04-11
 
 ### Added


### PR DESCRIPTION
# Description

ARM deployments in complete mode clear out a resourcegroup.
All existing resources are checked now, not just the ones that would be deployed 

### Checklist

- [X] Issue referenced with #
- [X] Build for push succeeded
- [X] Changelog updated
- [X] Version in psd updated
- [ ] Docs updated _nvt_
