### PR TITLE
Fixes #32 improve get arm deployment error message

### DIFF
--- a/ARMHelper/ARMHelper.psd1
+++ b/ARMHelper/ARMHelper.psd1
@@ -10,7 +10,7 @@
     RootModule        = 'ARMHelper.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.6.1'
+    ModuleVersion     = '0.6.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/ARMHelper/Public/Get-ARMDeploymentErrorMessage.ps1
+++ b/ARMHelper/Public/Get-ARMDeploymentErrorMessage.ps1
@@ -187,7 +187,36 @@ function Get-ARMDeploymentErrorMessage {
             if ($maxtries -gt 5 ) {
                 Throw "Can't get Azure Log Entry. Please check the log manually in the portal."
             }
+
+            # $LogContent | ConvertFrom-Json
+            # $TestError = $DetailedError | ConvertFrom-Json
+
             $DetailedError = $LogContent[0].statusMessage
+            $TestError = $DetailedError | ConvertFrom-Json
+    #         $ErrorMessage = Get-ResourceProperty -Object $TestError
+    #         $Notrelevant = @(
+    #             '.*PreflightValidationCheck*',
+    #             '.*InvalidTemplateDeployment.*'
+
+    #         )
+    #         $goodcode = @()
+    #         foreach ($prop in $ErrorMessage.GetEnumerator()){
+    #             if ($prop.Key -like "*code*") {
+
+    #                if ( $goodprop = $prop.Value -notmatch  ($Notrelevant -join "|")){
+    #                 $ErrorCode = $Prop.Value
+    #                 $Segments = (($Prop.Key).Split(".")).count
+
+    #                }
+    #             }
+
+    #          #   Write-output "key " $prop.Key
+    #          #   Write-output "value" $prop.Value
+    #         }
+    #    $props = $ErrorMessage.Values  -notmatch  ($Notrelevant -join "|")
+
+
+
             $TestError = ($DetailedError | ConvertFrom-Json ).error.details.details
             if ([string]::IsNullOrEmpty($testError)) {
                 $ErrorCode = ($DetailedError | ConvertFrom-Json ).error.details.code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-##[0.6.1]
+##[0.6.2]
 
 ### Added
 
@@ -14,13 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A warning is added to Test-ARMExistingResource as this module can't support Microsoft.Resources/deployments at this time (30)
+- Get-ARMDeploymentErrorMessage had issues lately because the output from the Azure Log is not always consistent. It now searches for the right properties in a different way (#32)
+
 
 ## [0.5.7] - 2019-08-15
 
 ### Fixed
 
 - The check for AzureRm/Az broke for the Azure DevOps pipeline. This is fixed
-  This also fixes #23 as Az is now the prefered module
+  This also fixes #23 as Az is now the preferred module
 
 ## [0.5.6] - 2019-07-20
 


### PR DESCRIPTION
# Description

I have changed the structure of the code that searches the AzureLog for the correct error message. As the properties aren't consistent in there position, they are now all searched for the correct context.

Also I have increased the time allowed to get content from the log, as this is unfortunately getting slower and slower :(
### Checklist

- [X] Issue referenced with #
- [X] Build for push succeeded
- [X] Changelog updated
- [X] Version in psd updated
- [-] Docs updated
